### PR TITLE
fix main file path, change to relative path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-text-ellipsis",
   "version": "1.2.1",
   "description": "react multi-line ellipsis",
-  "main": "/dist/bundle.js",
+  "main": "dist/bundle.js",
   "scripts": {
     "example": "webpack -d --config webpack.example.config.js",
     "build": "webpack -p"


### PR DESCRIPTION
I'm having an issue where this package is working great in reality, but causing eslint and test suites to fail because they cannot resolve the main entry point to the package.

I think the main entry point is meant to be relative to the package directory, rather than absolute.

Thanks very much for this great package