### PR TITLE
bug fix: react complains about PropTypes.shape

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ TextEllipsis.propTypes = {
   debounceTimeoutOnResize: PropTypes.number,
   useJsOnly: PropTypes.bool,
   onResult: PropTypes.func,
-  style: PropTypes.shape,
+  style: PropTypes.object,
 };
 
 TextEllipsis.defaultProps = {


### PR DESCRIPTION
Replaced invalid use of PropTypes.shape with PropTypes.object.

React prints this to console on every render call in development mode:

> type specification of prop `style` is invalid; the type checker function must return `null` or an `Error` but returned a function. You may have forgotten to pass an argument to the type checker creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and shape all require an argument).