### PR TITLE
Fix an error on the window resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ class TextEllipsis extends React.Component {
 
     this.isSupportNativeClamp = this.props.useJsOnly ? false : 'webkitLineClamp' in document.body.style;
     this.truncate = this.truncate.bind(this);
+    this.process = this.process.bind(this);
     this.debounceProcess = debounce(this.process, this.props.debounceTimeoutOnResize);
   }
 


### PR DESCRIPTION
Hi @tjindapitak , thanks for the package!

## Context
I've found the error on resize:
  > Uncaught TypeError: Cannot read property 'length' of undefined

See the gif with repo example.
![react-text-ellipsis-error-on-resize](https://user-images.githubusercontent.com/5443359/44970710-ab8f9a80-af5b-11e8-863b-3a0f854ddc6f.gif)


The reason for it is that the process() (which we call inside
event handler) leaves the context. 'This' doesn't point to a component.
'This' points to the window.

As a result, we have the error in this line https://github.com/tjindapitak/react-text-ellipsis/blob/master/src/index.js#L79

## Solution
To fix it we should bind process() to this inside constructor too as we do for truncate().